### PR TITLE
Clear persisted store while first time setup

### DIFF
--- a/first_time_setup.sh
+++ b/first_time_setup.sh
@@ -38,13 +38,15 @@ echo " "
 echo "=============================="
 echo "BUILDING APPLICATION"
 echo "=============================="
-(cd $GUI && yarn build && printf "${GREEN}done${NC}")
+
+# Set environment variable "LAST_FIRST_TIME_SETUP_TIMESTAMP" at build time to create a new timestamp while serving the app.
+(cd $GUI && REACT_APP_LAST_FIRST_TIME_SETUP_TIMESTAMP=$(date +%s) yarn build && printf "${GREEN}done${NC}")
 fi
 
-# remove existing dockers 
+# remove existing dockers
 ./remove_dockers.sh
 
-./quick_start.sh $1
+./quick_start.sh $1 --first-time-setup
 
 P1=$!
 

--- a/packages/ui-gui-nodeos/src/index.js
+++ b/packages/ui-gui-nodeos/src/index.js
@@ -7,16 +7,23 @@ import { PersistGate } from 'redux-persist/integration/react'
 import store, { history, persistor } from 'store';
 import App from 'app';
 
-const currentLastTimestamp = process.env.REACT_APP_LAST_FIRST_TIME_SETUP_TIMESTAMP || 1;
-const storedLastTimestamp = localStorage.getItem('lastTimestamp');
+const currentLastTimestamp = process.env.REACT_APP_LAST_FIRST_TIME_SETUP_TIMESTAMP;
 
-//If the current last timestamp from process.env does not match the stored one, it means user has initiated a new first time setup.
-//Hence, clear the whole persisted store.
-if ( currentLastTimestamp !== storedLastTimestamp ){
-  persistor.purge();
+// If currentLastTimestamp is not defined, current application run must not start from a first time setup script.
+// Hence, ignore below steps for not clearing persisted store and not setting local storage variable.
+if ( currentLastTimestamp ){
+
+  const storedLastTimestamp = localStorage.getItem('lastTimestamp');
+
+  // If the current last timestamp from process.env does not match the stored one, it means user has initiated a new first time setup.
+  // Hence, clear the whole persisted store.
+  if ( currentLastTimestamp !== storedLastTimestamp ){
+    persistor.purge();
+  }
+
+  localStorage.setItem('lastTimestamp', currentLastTimestamp);
+
 }
-
-localStorage.setItem('lastTimestamp', currentLastTimestamp);
 
 const AppBundle = (
   <Provider store={store}>

--- a/quick_start.sh
+++ b/quick_start.sh
@@ -96,10 +96,12 @@ echo " "
 echo "=============================="
 echo "STARTING GUI"
 echo "=============================="
+
+# $2 should be either argument "--first-time-setup" or null
 if $ISDEV; then
-  ./start_gui.sh -dev
+  ./start_gui.sh -dev $2
 else
-  ./start_gui.sh
+  ./start_gui.sh $2
 fi
 
 P1=$!

--- a/start_gui.sh
+++ b/start_gui.sh
@@ -7,10 +7,19 @@ GREEN='\033[0;32m'
 SCRIPTPATH="$( pwd -P )"
 GUI="$SCRIPTPATH/packages/ui-gui-nodeos"
 ISDEV=false
+ISFIRSTTIMESETUP=false
 
-if [ "$1" == "-dev" -o "$1" == "--develop" ]; then
-  ISDEV=true
-fi
+for arg in $@
+do
+    case $arg in
+      -dev|--develop)
+        ISDEV=true
+        ;;
+      --first-time-setup)
+        ISFIRSTTIMESETUP=true
+        ;;
+  esac
+done
 
 echo 'in start ' + $ISDEV
 
@@ -19,7 +28,12 @@ echo "=============================="
 echo "STARTING GUI"
 echo "=============================="
 if $ISDEV; then
-  (cd $GUI && yarn start)
+  if $ISFIRSTTIMESETUP; then
+    # Set environment variable "LAST_FIRST_TIME_SETUP_TIMESTAMP" at dev build to create a new timestamp in CRA development
+    (cd $GUI && REACT_APP_LAST_FIRST_TIME_SETUP_TIMESTAMP=$(date +%s) yarn start)
+  else
+    (cd $GUI && yarn start)
+  fi
 else
   (cd $GUI && yarn serve)
 fi


### PR DESCRIPTION
Clear local storage if first time setup is initiated.
Clear persisted store if .env.local last timestamp variable is changed.
Add last first time setup timestamp environment variable when user runs first time setup in both dev / production mode ( yarn start / yarn build -> yarn serve ).