### PR TITLE
Major UI modifications and improvements

### DIFF
--- a/packages/api-eosio-compiler/docker-eosio-cdt/contracts/tataworld.cpp
+++ b/packages/api-eosio-compiler/docker-eosio-cdt/contracts/tataworld.cpp
@@ -2,14 +2,14 @@
 #include <eosiolib/print.hpp>
 using namespace eosio;
 
-class [[eosio::contract("byeworld")]] byeworld : public contract {
+class [[eosio::contract("tataworld")]] tataworld : public contract {
   public:
       using contract::contract;
 
       [[eosio::action]]
       void sendmsg(const std::string &msg) {
-         print( "bye, ", msg );
+         print( "Wilkommen, ", msg );
       }
 };
 
-EOSIO_DISPATCH( byeworld, (sendmsg) )
+EOSIO_DISPATCH( tataworld, (sendmsg) )

--- a/packages/ui-gui-nodeos/src/components/DragDropCodeViewer/DragDropCodeViewer.jsx
+++ b/packages/ui-gui-nodeos/src/components/DragDropCodeViewer/DragDropCodeViewer.jsx
@@ -83,10 +83,10 @@ class DragDropCodeViewer extends Component {
                 <div {...getRootProps()}>
                   <input {...getInputProps()} />
                     <Jumbotron>
-                      <p className="lead text-center">Drag and Drop files <strong>here</strong> or click <strong>browse</strong> to choose a file.</p>
-                      <hr className="my-4" />
+                      <p id="ddLabel" className="lead text-center">Drag & Drop files <strong>here</strong> or click <strong>Browse</strong> to choose a file.</p>
+                      <br />
                       <p className="lead text-center browseButton">
-                        <ButtonPrimary onClick={(e) => e.preventDefault()} >Browse</ButtonPrimary>
+                        <ButtonPrimary onClick={(e) => e.preventDefault()} >BROWSE</ButtonPrimary>
                       </p>
                     </Jumbotron>
                 </div>

--- a/packages/ui-gui-nodeos/src/components/DragDropCodeViewer/DragDropCodeViewer.scss
+++ b/packages/ui-gui-nodeos/src/components/DragDropCodeViewer/DragDropCodeViewer.scss
@@ -3,20 +3,29 @@
     overflow: hidden;
     border: 1px solid #eee;
     border-radius: 3px;
+    height: 80%;
 
     .jumbotron {
       border-radius: 0;
+      background-color: #f8f9fa !important;
     }
 
     .dropzone {
       height: 100%;
-
       > div {
         height:100%;
       }
       .jumbotron {
         height: 100%;
-        margin:0;
+        width: 100%;
+        margin: 0;
+
+        p#ddLabel {
+          width: 20%;
+          margin-top: 4em;
+          margin-left: 40%;
+        }
+
       }
     }
   
@@ -35,16 +44,24 @@
           padding: 1em;
           margin: 0;
           height: 5em;
+          width: 100%;
   
           p.lead {
-            font-size: 1em;
+            font-size: 14px;
             text-align: left !important;
-            width: 75%;
+            width: 75% !important;
             float: left;
             margin-top: 0.15em;
           }
+
+          p#ddLabel {
+            margin-top: 0.15em;
+            margin-left: 0;
+            width: inherit;
+          }
+
           p.lead.browseButton {
-            width: 25%;
+            width: 25% !important;
             text-align: right !important;
             margin: 0;
             padding-right: 1em;
@@ -54,7 +71,7 @@
               font-size: 0.76562rem;
               line-height: 1;
               border-radius: 0.2rem;
-              margin-top: -0.5em;
+              margin-top: -3.2em;
             }
           }
           hr {

--- a/packages/ui-gui-nodeos/src/components/HelpFAB/HelpFAB.jsx
+++ b/packages/ui-gui-nodeos/src/components/HelpFAB/HelpFAB.jsx
@@ -5,8 +5,10 @@ import './HelpFAB.scss';
 
 function HelpFAB() {
   return (
-    <div className="HelpFAB text-center">
-      <Link to="//github.com/EOSIO/eosio-toppings/blob/develop/help.md" target="_blank" className="btn btn-pill btn-primary fab" >?</Link>
+    <div className="HelpFAB">
+      <Link to="//github.com/EOSIO/eosio-toppings/blob/develop/help.md" target="_blank" className="btn btn-pill btn-primary fab">
+        <i className="material-icons md-fab">help</i>
+      </Link>
     </div>
   )
 }

--- a/packages/ui-gui-nodeos/src/components/HelpFAB/HelpFAB.scss
+++ b/packages/ui-gui-nodeos/src/components/HelpFAB/HelpFAB.scss
@@ -9,5 +9,16 @@
     position: fixed;
     z-index: 1;
     border-radius: 50%;
+    height: 48px;
+    width: 48px;
+    background-color: #ffffff !important;
+    border: 1px solid #667d9a !important;
   };
+
+  .material-icons.md-fab {
+    font-size: 60px;
+    color: #667d9a;
+    margin-top: -12px;
+    margin-left: -18px;
+  }
 }

--- a/packages/ui-gui-nodeos/src/pages/ActiondetailPage/components/Actiondetail/Actiondetail.jsx
+++ b/packages/ui-gui-nodeos/src/pages/ActiondetailPage/components/Actiondetail/Actiondetail.jsx
@@ -19,7 +19,7 @@ const Actiondetail = (props) => {
               <Label>Smart Contract Name:</Label>
             </Col>
             <Col xs="10">
-              <p className="form-control-static">{action && action.act.account}</p>
+              <p className="form-control-static hashText">{action && action.act.account}</p>
             </Col>
           </FormGroup>
           <FormGroup row className="mb-0">
@@ -27,7 +27,7 @@ const Actiondetail = (props) => {
               <Label>Action Type:</Label>
             </Col>
             <Col xs="10">
-              <p className="form-control-static">{action && action.act.name}</p>
+              <p className="form-control-static hashText">{action && action.act.name}</p>
             </Col>
           </FormGroup>
           <FormGroup row className="mb-0">
@@ -35,7 +35,7 @@ const Actiondetail = (props) => {
               <Label>Timestamp:</Label>
             </Col>
             <Col xs="10">
-              <p className="form-control-static">{action && action.createdAt}</p>
+              <p className="form-control-static hashText">{action && action.createdAt}</p>
             </Col>
           </FormGroup>
           <FormGroup row className="mb-0">
@@ -53,7 +53,7 @@ const Actiondetail = (props) => {
               <Label>Actor:</Label>
             </Col>
             <Col xs="10">
-              <p className="form-control-static">
+              <p className="form-control-static hashText">
                 { action && (action.act && (action.act.authorization && 
                   action.act.authorization.map((auth, i) => (
                     auth.actor + (i > 0 && i < (action.act.authorization.length - 1) ? ", " : "")

--- a/packages/ui-gui-nodeos/src/pages/BlockdetailPage/components/Blockdetail/Blockdetail.jsx
+++ b/packages/ui-gui-nodeos/src/pages/BlockdetailPage/components/Blockdetail/Blockdetail.jsx
@@ -46,7 +46,7 @@ const Blockdetail = (props) => {
                               <Form> 
                                 <FormGroup row>
                                   <Col sm={2}>Block Number:</Col>
-                                  <Col sm={10}>
+                                  <Col sm={10} className="hashText">
                                     {payload[0].block_num}
                                   </Col>
                                 </FormGroup>
@@ -58,13 +58,13 @@ const Blockdetail = (props) => {
                                 </FormGroup>
                                 <FormGroup row>
                                   <Col sm={2}>Timestamp:</Col>
-                                  <Col sm={10}>
+                                  <Col sm={10} className="hashText">
                                     {payload[0].createdAt}
                                   </Col>
                                 </FormGroup>
                                 <FormGroup row>
                                   <Col sm={2}>Number of Transactions:</Col>
-                                  <Col sm={10}>
+                                  <Col sm={10} className="hashText">
                                     {payload[0].block.transactions.length}
                                   </Col>
                                 </FormGroup>

--- a/packages/ui-gui-nodeos/src/pages/DeploymentPage/DeploymentPageReducer.js
+++ b/packages/ui-gui-nodeos/src/pages/DeploymentPage/DeploymentPageReducer.js
@@ -30,6 +30,15 @@ export const outputClear = () => ({ type: OUTPUT_CLEAR });
 export const processDone = payload => ({ type: PROCESS_DONE, payload });
 export const processFail = (payload, error) => ({ type: PROCESS_FAIL, payload, error });
 
+/**
+ * Define constants to match the action state
+ * The UI's useEffect relies on this state to determine what kind of toast to show
+ * Fixes a problem where toast won't display if user deploys a contract after generating ABI
+ */
+const INIT_STATE = 0;
+const COMPILE_STATE = 1;
+const DEPLOY_STATE = 2;
+
 const importEpic = (action$) => action$.pipe(
   ofType(ABI_IMPORT),
   mergeMap(action => {
@@ -66,6 +75,7 @@ const compileEpic = (action$) => action$.pipe(
           wasmPath: wasmLocation,
           stdoutLog: (stdout instanceof Array) ? stdout : nodeStd,
           stderrLog: (stderr instanceof Array) ? stderr : nodeErr,
+          compilerState: COMPILE_STATE,
           compiled: compiled,
           errors: errors,
           imported: false
@@ -106,6 +116,7 @@ const deployEpic = (action$) => action$.pipe(
           wasmPath: wasmLocation,
           stdoutLog: (stdout instanceof Array) ? stdout : nodeStd,
           stderrLog: (stderr instanceof Array) ? stderr : nodeErr,
+          compilerState: DEPLOY_STATE,
           compiled: compiled,
           deployed: deployed,
           output: (actualOutput) ? actualOutput : null,
@@ -153,6 +164,7 @@ const dataInitState = {
   wasmPath: "",
   abiPath: "",
   abiContents: "",
+  compilerState: INIT_STATE,
   output: null,
   compiled: false,
   imported: false,
@@ -183,6 +195,7 @@ const deploymentReducer = (state = dataInitState, action) => {
         deployed: false,
         compiled: false,
         imported: false,
+        compilerState: INIT_STATE,
         errors: [],
         stderrLog: [],
         stdoutLog: [],
@@ -191,6 +204,7 @@ const deploymentReducer = (state = dataInitState, action) => {
     case OUTPUT_CLEAR:
       return {
         ...state,
+        compilerState: INIT_STATE,
         stdoutLog: [],
         stderrLog: [],
         errors: [],

--- a/packages/ui-gui-nodeos/src/pages/DeploymentPage/components/InputInstructions/InputInstructions.jsx
+++ b/packages/ui-gui-nodeos/src/pages/DeploymentPage/components/InputInstructions/InputInstructions.jsx
@@ -1,38 +1,51 @@
 import React, { Component } from 'react';
 import {
-  CardBody, ListGroup, ListGroupItem
+  CardBody
 } from 'reactstrap';
-import { CardStyled, CardHeaderStyled } from 'styled';
+import { CardStyled } from 'styled';
+import styled from 'styled-components';
+
+const CardStyledNoBorder = styled(CardStyled)`
+  border-top: solid 1px #e5e5e5;
+`
+
+const OrderedList = styled.ol`
+  li {
+    margin-top: 1.5em;
+  }
+`
 class InputInstructions extends Component {
 
   render() {
     return (
-      <CardStyled>
-        <CardHeaderStyled>
-          Entry Point File Upload Instructions
-        </CardHeaderStyled>
+      <CardStyledNoBorder>
         <CardBody>
-          <ListGroup>
-            <ListGroupItem>1. Drag and drop (or browse for it) the chosen entry file to the grey area</ListGroupItem>
-            <ListGroupItem>2. Double check your source code file and dependencies</ListGroupItem>
-            <ListGroupItem>
-              3. <b>Enter the absolute folder path containing this file</b> into the field indicated as
+          <strong>Entry Point File Upload Instructions:</strong>
+          <OrderedList>
+            <li>
+              Drag and drop (or browse for it) the chosen entry file to the grey area
+            </li>
+            <li>
+              Double check your source code file and dependencies
+            </li>
+            <li>
+              <b>Enter the absolute folder path containing this file</b> into the field indicated as
               "Root Folder Path". This path will be saved locally for future use. All files in this root folder
               will be used as part of the compilation process.
-            </ListGroupItem>
-            <ListGroupItem>
-              4. <b>Optional Step 2</b>: Generate your ABI file first by clicking "Generate ABI". The result of
+            </li>
+            <li>
+              <b>Optional Step 2</b>: Generate your ABI file first by clicking "Generate ABI". The result of
               compilation will appear in the code viewer. View the ABI / Deployment Log for any warnings
               or errors. You may also choose to import an ABI file by clicking "Import ABI" instead.
-            </ListGroupItem>
-            <ListGroupItem>
-              5. Go to Step 3, deploy. If you're sure your contract works, you can deploy to the Nodeos instance you are
+            </li>
+            <li>
+              Go to Step 3, deploy. If you're sure your contract works, you can deploy to the Nodeos instance you are
               currently connected to by clicking on Deploy after selecting the permission you want
               to deploy the contract as. <b>Note: You cannot deploy as 'eosio' since 'eosio' owns the system contract.</b>
-            </ListGroupItem>
-          </ListGroup>
+            </li>
+          </OrderedList>
         </CardBody>
-      </CardStyled>
+      </CardStyledNoBorder>
     )
   }
 

--- a/packages/ui-gui-nodeos/src/pages/InfoPage/components/BlockchainInfo/BlockchainInfo.jsx
+++ b/packages/ui-gui-nodeos/src/pages/InfoPage/components/BlockchainInfo/BlockchainInfo.jsx
@@ -31,7 +31,7 @@ const BlockchainInfo = (props) => {
             <Col xs="2">
               <Label>Server Version:</Label>
             </Col>
-            <Col xs="10">
+            <Col xs="10" className="hashText">
               <p className="form-control-static">{payload && payload.server_version}</p>
             </Col>
           </FormGroup>
@@ -39,7 +39,7 @@ const BlockchainInfo = (props) => {
             <Col xs="2">
               <Label>Server Version String:</Label>
             </Col>
-            <Col xs="10">
+            <Col xs="10" className="hashText">
               <p className="form-control-static">{payload && payload.server_version_string}</p>
             </Col>
           </FormGroup>
@@ -47,7 +47,7 @@ const BlockchainInfo = (props) => {
             <Col xs="2">
               <Label>Chain ID:</Label>
             </Col>
-            <Col xs="10">
+            <Col xs="10" className="hashText">
               <p className="form-control-static hashText">{payload && payload.chain_id}</p>
             </Col>
           </FormGroup>

--- a/packages/ui-gui-nodeos/src/pages/InfoPage/components/Headblock/Headblock.jsx
+++ b/packages/ui-gui-nodeos/src/pages/InfoPage/components/Headblock/Headblock.jsx
@@ -32,7 +32,7 @@ const Headblock = (props) => {
             <Col xs="2">
               <Label>Block Number:</Label>
             </Col>
-            <Col xs="10" >
+            <Col xs="10" className="hashText">
               <p className="form-control-static">{block_num}</p>
             </Col>
           </FormGroup>
@@ -48,7 +48,7 @@ const Headblock = (props) => {
             <Col xs="2">
               <Label>Timestamp:</Label>
             </Col>
-            <Col xs="10">
+            <Col xs="10" className="hashText">
               <p className="form-control-static">{block && block.timestamp}</p>
             </Col>
           </FormGroup>
@@ -56,7 +56,7 @@ const Headblock = (props) => {
             <Col xs="2">
               <Label>Block Producer:</Label>
             </Col>
-            <Col xs="10">
+            <Col xs="10" className="hashText">
               <p className="form-control-static">{block && block.producer}</p>
             </Col>
           </FormGroup>

--- a/packages/ui-gui-nodeos/src/pages/InfoPage/components/LastIrreversibleBlockInfo/LastIrreversibleBlockInfo.jsx
+++ b/packages/ui-gui-nodeos/src/pages/InfoPage/components/LastIrreversibleBlockInfo/LastIrreversibleBlockInfo.jsx
@@ -28,7 +28,7 @@ const LastIrreversibleBlockInfo = (props) => {
             <Col xs="2">
               <Label>Block Number:</Label>
             </Col>
-            <Col xs="10">
+            <Col xs="10" className="hashText">
               <p className="form-control-static">{payload && payload.last_irreversible_block_num}</p>
             </Col>
           </FormGroup>

--- a/packages/ui-gui-nodeos/src/pages/InfoPage/components/Nodeswitch/Nodeswitch.jsx
+++ b/packages/ui-gui-nodeos/src/pages/InfoPage/components/Nodeswitch/Nodeswitch.jsx
@@ -44,10 +44,10 @@ const Nodeswitch = (props) => {
     <div className="Nodeswitch">
       <Form key={key}>
         <FormGroup row className="mb-0">
-          <Col xs="3">
+          <Col xs="2">
             <CenteredLabel htmlFor="nodeos">Connected Nodeos:</CenteredLabel>
           </Col>
-          <Col xs="9">
+          <Col xs="10">
             <InputStyled
               type="text"
               id="nodeos"
@@ -64,10 +64,10 @@ const Nodeswitch = (props) => {
                 </FormFeedback>
               }
           </Col>
-          <Col xs="3" style={{marginTop: "10px"}}>
+          <Col xs="2" style={{marginTop: "10px"}}>
             <CenteredLabel htmlFor="mongodb">Connected MongoDB</CenteredLabel>
           </Col>
-          <Col xs="9" style={{marginTop: "10px"}}>
+          <Col xs="10" style={{marginTop: "10px"}}>
             <InputStyled
               type="text"
               id="mongodb"

--- a/packages/ui-gui-nodeos/src/pages/PermissionPage/components/ImportAccount/ImportAccount.jsx
+++ b/packages/ui-gui-nodeos/src/pages/PermissionPage/components/ImportAccount/ImportAccount.jsx
@@ -108,8 +108,9 @@ const ImportAccount = (props) => {
                         keysData[0].permission === "owner" ?
                           keysData[0].public_key
                           : keysData[1].public_key
-                          || "No public key"
+                          || ""
                       }
+                      placeholder="Public key not found"
                       onChange={handleChange}
                       readOnly
                     />
@@ -125,8 +126,9 @@ const ImportAccount = (props) => {
                         keysData[0].permission === "owner" ?
                           keysData[0].private_key
                           : keysData[1].private_key
-                          || "No private key"
+                          || ""
                       }
+                      placeholder="Enter private key"
                       onChange={handleChange}
                       invalid={!!errors.ownerPrivate}
                       required
@@ -150,8 +152,9 @@ const ImportAccount = (props) => {
                         keysData[1].permission === "active" ?
                           keysData[1].public_key
                           : keysData[0].public_key
-                          || "No public key"
+                          || ""
                       }
+                      placeholder="Public key not found"
                       onChange={handleChange}
                       readOnly
                     />
@@ -167,8 +170,9 @@ const ImportAccount = (props) => {
                         keysData[1].permission === "active" ?
                           keysData[1].private_key
                           : keysData[0].private_key
-                          || "No private key"
+                          || ""
                       }
+                      placeholder="Enter private key"
                       onChange={handleChange}
                       invalid={!!errors.activePrivate}
                       required

--- a/packages/ui-gui-nodeos/src/pages/TransactiondetailPage/components/Transactiondetail/Transactiondetail.jsx
+++ b/packages/ui-gui-nodeos/src/pages/TransactiondetailPage/components/Transactiondetail/Transactiondetail.jsx
@@ -56,19 +56,19 @@ const Transactiondetail = (props) => {
                                 </FormGroup>
                                 <FormGroup row>
                                   <Col sm={2}>Block Number:</Col>
-                                  <Col sm={10}>
+                                  <Col sm={10} className="hashText">
                                     {payload[0].block_num}
                                   </Col>
                                 </FormGroup>
                                 <FormGroup row>
                                   <Col sm={2}>Timestamp:</Col>
-                                  <Col sm={10}>
+                                  <Col sm={10} className="hashText">
                                     {payload[0].createdAt}
                                   </Col>
                                 </FormGroup>
                                 <FormGroup row>
                                   <Col sm={2}>Number of Actions:</Col>
-                                  <Col sm={10}>
+                                  <Col sm={10} className="hashText">
                                     {payload[0].action_traces.length}
                                   </Col>
                                 </FormGroup>

--- a/packages/ui-gui-nodeos/src/styled/ButtonPrimary.js
+++ b/packages/ui-gui-nodeos/src/styled/ButtonPrimary.js
@@ -5,7 +5,7 @@ export default styled(Button)`
   width: 130px;
   height: 40px;
   border-radius: 2px;
-  background-color: #4d9cc3;
+  background-color: #443f54;
   opacity: 1;
   color: #ffffff;
   font-size: 14px;
@@ -14,21 +14,21 @@ export default styled(Button)`
   padding: 8px 8px 10px 8px;
 
   :disabled{
-    background-color: #4d9cc3;
+    background-color: #a4a4a4;
     cursor: not-allowed;
     color: #ffffff;
   }
   :disabled:hover{
-    background-color: #4d9cc3;
+    background-color: #a4a4a4;
     opacity: 0.65;
   }
   :hover{
-    background-color: #407893;
+    background-color: #201c2c;
     opacity: 1;
     color: #ffffff;
   }
   :not(:disabled):not(.disabled):active{
-    background-color: #2a4c5d;
+    background-color: #201c2c;
     opacity: 1;
     color: #ffffff;
   }

--- a/packages/ui-gui-nodeos/src/styled/ButtonSecondary.js
+++ b/packages/ui-gui-nodeos/src/styled/ButtonSecondary.js
@@ -5,7 +5,7 @@ export default styled(Button)`
   width: 130px;
   height: 40px;
   border-radius: 2px;
-  background-color: #bcbcbc;
+  background-color: #667d9a;
   opacity: 1;
   color: #ffffff;
   font-size: 14px;
@@ -14,17 +14,17 @@ export default styled(Button)`
   padding: 8px 8px 10px 8px;
 
   :disabled{
-    background-color: #bcbcbc;
+    background-color: #a4a4a4;
     opacity: 1;
     color: #ffffff;
   }
   :hover{
-    background-color: #9b9b9b;
+    background-color: #435a77;
     color: #ffffff;
     opacity: 1;
   }
   :not(:disabled):not(.disabled):active{
-    background-color: #838187;
+    background-color: #667d9a;
     opacity: 1;
     color: #ffffff;
   }

--- a/packages/ui-gui-nodeos/src/styled/DropdownStyled.js
+++ b/packages/ui-gui-nodeos/src/styled/DropdownStyled.js
@@ -39,8 +39,11 @@ export default styled(Dropdown)`
     border: 0;
     transform: translate3d(0, 40px, 0px);
   }
+  .dropdown-item:hover {
+    background-color: #e3edf2;
+  }
   .dropdown-item:active{
-      background-color: #e3edf2;
+    background-color: #e3edf2;
   }
   .dropdown-item:focus{     
     outline: none;


### PR DESCRIPTION
Changes
---
* (3291) - Fixed bug in the deployment page where Generate ABI and Deploy tooltips would be sticky even after clicking it by changing them to `Tooltip` instead of `UncontrolledTooltip`
* (3291) - Fixed toast not properly appearing on the page in the case where user would deploy after they have previously generated the same contract ABI. This involves adding a 'compiler state' value in the redux store which checks whether the compiler is in an idle/init state, in a compiling state or in a deploying state.
* (3292) - Modified `HelpFAB` to match the updated design spec by using the material icon
* (3293) - Modified the deployment page to match the updated design spec
* (3294) - Modified `ButtonPrimary` and `ButtonSecondary` to match the updated design spec
* (3296) - Modified the data text in all detail pages to be in `monospace`
* (3297) - Modified the data text in the info page to be in `monospace`
* (3297) - Properly aligned the input field in the Node Switcher component