### PR TITLE
Fixed ricardian contracts not properly importing

### DIFF
--- a/packages/api-eosio-compiler/helpers.js
+++ b/packages/api-eosio-compiler/helpers.js
@@ -73,10 +73,10 @@ const fetchDeployableFilesFromDirectory = (directory) => {
 
 }
 
-const filterHeaderFiles = (fileName) => (fileName.includes('.hpp'));
+const filterHeaderFiles = (fileName) => (fileName.includes('.hpp') || fileName.includes('.md') || fileName.includes('.yml') || fileName.includes('yaml'));
 
 const parseDirectoriesToInclude = (sourcePath) => {
-  let directories = [];
+  let directories = ['/opt/eosio/bin/contracts/'];
   let i = 0;
 
   try {


### PR DESCRIPTION
Fixed service component not properly detecting Ricardian contracts (`.md`, `.yml`, `.yaml`) and thus importing them into the ABI 