### PR TITLE
Roll back changes from erroneous release

### DIFF
--- a/packages/api-eosio-compiler/helpers.js
+++ b/packages/api-eosio-compiler/helpers.js
@@ -76,7 +76,7 @@ const fetchDeployableFilesFromDirectory = (directory) => {
 const filterHeaderFiles = (fileName) => (fileName.includes('.hpp') || fileName.includes('.md') || fileName.includes('.yml') || fileName.includes('yaml'));
 
 const parseDirectoriesToInclude = (sourcePath) => {
-  let directories = ['/opt/eosio/bin/contracts/'];
+  let directories = [];
   let i = 0;
 
   try {


### PR DESCRIPTION
Buggy release 0.3.6 for `api-eosio-compiler`