### PR TITLE
Action filter - Accept multiple account names

### DIFF
--- a/packages/api-postgres-plugin/api/get_action_history.js
+++ b/packages/api-postgres-plugin/api/get_action_history.js
@@ -1,13 +1,20 @@
 const db = require('./db');
 
-const get_actions = async (query) => {
+const get_action_history = async (query) => {
   try{
-    let { account_name, records_count, fetch_failed_action } = query;
+    let { account_name, actor_name, records_count } = query;
 
     let query_gen = `
     SELECT transaction_id, action_ordinal, act_account, act_name, act_data, timestamp, block_num, actor, permission
     FROM chain.action_trace
-    WHERE creator_action_ordinal = 0 ${(account_name !== undefined) ? `AND act_account = '${account_name}'` : '' }  
+    WHERE creator_action_ordinal = 0 
+    ${(account_name !== undefined && actor_name !== undefined) ? 
+      `AND (act_account = ANY('{${account_name}}') OR actor = ANY('{${actor_name}}'))` :
+    (account_name !== undefined) ?
+      `AND act_account = ANY('{${account_name}}')` :
+    (actor_name !== undefined) ? 
+      `AND actor = ANY('{${actor_name}}')` :
+    ``}
     ORDER BY block_num DESC
     LIMIT ${(records_count !== undefined) ? parseInt(records_count) :  100}`;
     
@@ -15,7 +22,7 @@ const get_actions = async (query) => {
     let promise = new Promise((resolve, reject)=>{
       db.query(query_gen, "", (err, result) => {
         if (err) {
-          console.error('Error executing get actions query:: ', err.stack);
+          console.error('Error executing get action history query: ', err.stack);
           resolve([]);
         }else{
           resolve(result.rows);     
@@ -30,4 +37,4 @@ const get_actions = async (query) => {
   }
 }
 
-module.exports = get_actions;
+module.exports = get_action_history;

--- a/packages/api-postgres-plugin/api/get_actions.js
+++ b/packages/api-postgres-plugin/api/get_actions.js
@@ -5,13 +5,11 @@ const get_actions = async (query) => {
     let { account_name, records_count, fetch_failed_action } = query;
 
     let query_gen = `
-    SELECT at.transaction_id, at.action_ordinal, at.act_account, at.act_name, at.act_data, at.timestamp, at.block_num,
-    (SELECT ata.actor FROM chain.action_trace_authorization ata WHERE ata.block_num = at.block_num AND ata.transaction_id = at.transaction_id AND ata.action_ordinal = at.action_ordinal LIMIT 1),
-    (SELECT ata.permission FROM chain.action_trace_authorization ata WHERE ata.block_num = at.block_num AND ata.transaction_id = at.transaction_id AND ata.action_ordinal = at.action_ordinal LIMIT 1)
-    FROM chain.action_trace at
-    WHERE at.creator_action_ordinal = 0 ${(account_name !== undefined) ? `AND at.act_account = '${account_name}'`:  '' }  
-    ORDER BY at.block_num DESC
-    LIMIT ${(records_count !== undefined) ? parseInt(records_count) :  100}`;
+    SELECT transaction_id, action_ordinal, act_account, act_name, act_data, timestamp, block_num, actor, permission
+    FROM chain.action_trace
+    WHERE creator_action_ordinal = 0 ${(account_name !== undefined) ? `AND act_account = ANY('{${account_name}}')` :  '' }
+    ORDER BY block_num DESC
+    LIMIT ${(records_count !== undefined) ? parseInt(records_count) :  100}`;    
 
     let promise = new Promise((resolve, reject)=>{
       db.query(query_gen, "", (err, result) => {

--- a/packages/api-postgres-plugin/index.d.ts
+++ b/packages/api-postgres-plugin/index.d.ts
@@ -9,7 +9,7 @@ declare namespace Postgres {
   interface TransactionsQuery extends ListQuery { }
   interface TransactionDetailsQuery { id: string, endpoint: string }
 
-  interface ActionsQuery extends ListQuery { account_name?: string, fetch_failed_action?: boolean, no_limit?: boolean, records_count?: number }
+  interface ActionsQuery extends ListQuery { account_name?: string | string[], fetch_failed_action?: boolean, no_limit?: boolean, records_count?: number }
   interface ActionsWithFilterQuery extends ListQuery {
     action_filter: 'sent' | 'received' | 'signed' | 'contract',
     account_name: string,

--- a/packages/api-postgres-plugin/index.d.ts
+++ b/packages/api-postgres-plugin/index.d.ts
@@ -9,7 +9,8 @@ declare namespace Postgres {
   interface TransactionsQuery extends ListQuery { }
   interface TransactionDetailsQuery { id: string, endpoint: string }
 
-  interface ActionsQuery extends ListQuery { account_name?: string | string[], fetch_failed_action?: boolean, no_limit?: boolean, records_count?: number }
+  interface ActionsQuery extends ListQuery { account_name?: string, fetch_failed_action?: boolean, no_limit?: boolean, records_count?: number }
+  interface ActionHistoryQuery extends ListQuery { account_name?: string | string[], actor_name?: string | string[], fetch_failed_action?: boolean, no_limit?: boolean, records_count?: number }
   interface ActionsWithFilterQuery extends ListQuery {
     action_filter: 'sent' | 'received' | 'signed' | 'contract',
     account_name: string,
@@ -177,6 +178,7 @@ declare namespace Postgres {
   function get_transaction_details(query: TransactionDetailsQuery) : Promise<any>;
 
   function get_actions(query: ActionsQuery) : Promise<ActionResult[]>;
+  function get_action_history(query: ActionHistoryQuery) : Promise<ActionResult[]>;
   function get_action_details(query: ActionDetailsQuery) : Promise<ActionDetailsResult>;
   function get_actions_with_filter(query: ActionsWithFilterQuery) : Promise<TransactionResult[]>;
 

--- a/packages/api-postgres-plugin/index.js
+++ b/packages/api-postgres-plugin/index.js
@@ -8,6 +8,7 @@ const get_transaction_details = require('./api/get_transaction_details');
 const get_all_permissions = require('./api/get_all_permissions');
 const get_smart_contracts = require('./api/get_smart_contracts');
 const get_actions = require('./api/get_actions');
+const get_action_history = require('./api/get_action_history');
 const get_action_details = require('./api/get_action_details');
 const get_actions_with_filter = require('./api/get_actions_with_filter');
 const get_permissions_by_public_key = require('./api/get_permissions_by_public_key');
@@ -23,6 +24,7 @@ module.exports = {
   get_all_permissions,
   get_smart_contracts,
   get_actions,
+  get_action_history,
   get_action_details,
   get_actions_with_filter,
   get_permissions_by_public_key,


### PR DESCRIPTION
Created get_action_history API method in api-postgres-plugin to accept account_name and actor_name params as an array or a string and filter correctly in both cases